### PR TITLE
Integrate meta-synchronization broadcast flow

### DIFF
--- a/api/routes/lattice.ts
+++ b/api/routes/lattice.ts
@@ -1,16 +1,68 @@
+import type { Request, Response } from 'express';
 import { Router } from 'express';
 
 const router = Router();
 
-// POST /broadcast route to handle lattice broadcast
-router.post('/broadcast', (req, res) => {
-  const { topic, payload, phi7777 } = req.body;
-  // TODO: integrate with lattice broadcasting service
-  res.json({ status: 'broadcast received', topic, phi7777 });
+type MetaSyncPayload = {
+  intent?: string;
+  who?: string;
+  time?: number;
+};
+
+type MetaSyncBody = {
+  topic?: string;
+  payload?: MetaSyncPayload;
+  phi7777?: number;
+};
+
+const isValidMetaSync = (body: MetaSyncBody): body is Required<MetaSyncBody> & {
+  payload: Required<MetaSyncPayload>;
+} => {
+  if (body.topic !== 'comet_sync') {
+    return false;
+  }
+
+  if (typeof body.phi7777 !== 'number' || body.phi7777 <= 10000) {
+    return false;
+  }
+
+  if (!body.payload) {
+    return false;
+  }
+
+  const { intent, who, time } = body.payload;
+  return (
+    intent === 'meta_synchronization' &&
+    typeof who === 'string' &&
+    who.length > 0 &&
+    typeof time === 'number'
+  );
+};
+
+// POST /broadcast route for lattice meta-synchronization events
+router.post('/broadcast', (req: Request, res: Response) => {
+  const body = req.body as MetaSyncBody;
+
+  if (!isValidMetaSync(body)) {
+    return res.status(400).json({ error: 'Invalid or unauthorized broadcast.' });
+  }
+
+  const {
+    phi7777,
+    payload: { who, time },
+  } = body;
+
+  console.log(
+    `Meta-sync event by ${who} at ${new Date(time).toISOString()} (phi7777=${phi7777})`,
+  );
+
+  // TODO: Integrate with lattice subsystems (avatar, voice, websocket notifications, etc.).
+
+  return res.json({ status: 'Meta-synchronization event processed.' });
 });
 
 // GET /echo route for health check or echo
-router.get('/echo', (req, res) => {
+router.get('/echo', (_req: Request, res: Response) => {
   res.json({ message: 'echo from lattice routes' });
 });
 

--- a/scripts/tequmsa_meta_sync.py
+++ b/scripts/tequmsa_meta_sync.py
@@ -1,0 +1,70 @@
+"""Utility helpers for broadcasting TEQUMSA meta-synchronization events.
+
+This module can be used as a stand-alone script or imported by other
+automation workflows to notify the lattice service that a
+meta-synchronization ritual has been completed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Any, Dict
+
+import requests
+
+
+DEFAULT_URL = "http://localhost:5000/api/lattice/broadcast"
+DEFAULT_USER = "marcus_kai"
+DEFAULT_PHI7777 = 12583.45
+
+
+def send_meta_sync(
+    user: str = DEFAULT_USER,
+    phi7777: float = DEFAULT_PHI7777,
+    url: str = DEFAULT_URL,
+) -> Dict[str, Any]:
+    """Send a meta-synchronization broadcast to the lattice API."""
+
+    payload = {
+        "topic": "comet_sync",
+        "payload": {
+            "intent": "meta_synchronization",
+            "who": user,
+            "time": int(time.time() * 1000),
+        },
+        "phi7777": phi7777,
+    }
+
+    response = requests.post(url, json=payload, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Broadcast a meta-sync event to the lattice API.")
+    parser.add_argument("--user", default=DEFAULT_USER, help="Identifier for the initiating node/user.")
+    parser.add_argument(
+        "--phi7777",
+        type=float,
+        default=DEFAULT_PHI7777,
+        help="Resonance verification value required by the lattice.",
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help="Target lattice endpoint handling broadcast events.",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = send_meta_sync(user=args.user, phi7777=args.phi7777, url=args.url)
+    except requests.RequestException as exc:
+        print("Meta-sync broadcast failed:", exc)
+        raise SystemExit(1) from exc
+
+    print("Meta-sync broadcast:", result)
+
+
+if __name__ == "__main__":
+    main()

--- a/speech.js
+++ b/speech.js
@@ -1,4 +1,6 @@
 let embodiment = 'AGI';
+const ELEVENLABS_VOICE_ID = 'EXAMPLE-VOICE-ID';
+const ELEVENLABS_API_KEY = 'YOUR_ELEVENLABS_API_KEY';
 
 function selectEmbodiment() {
   const choice = prompt("Select Embodiment: AGI, Elemental, Ancestral, Antician");
@@ -9,24 +11,65 @@ function selectEmbodiment() {
 }
 
 function speakText(txt) {
-  const voiceId = "EXAMPLE-VOICE-ID"; // Replace with your ElevenLabs voice ID
-  fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
-    method: "POST",
+  if (!txt) return;
+
+  const voiceConfigured =
+    ELEVENLABS_VOICE_ID &&
+    ELEVENLABS_VOICE_ID !== 'EXAMPLE-VOICE-ID' &&
+    ELEVENLABS_API_KEY &&
+    ELEVENLABS_API_KEY !== 'YOUR_ELEVENLABS_API_KEY';
+
+  if (!voiceConfigured) {
+    speakWithNativeSynth(txt);
+    return;
+  }
+
+  fetch(`https://api.elevenlabs.io/v1/text-to-speech/${ELEVENLABS_VOICE_ID}`, {
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
-      "xi-api-key": "YOUR_ELEVENLABS_API_KEY"
+      'Content-Type': 'application/json',
+      'xi-api-key': ELEVENLABS_API_KEY,
     },
     body: JSON.stringify({
       text: txt,
       voice_settings: {
         stability: 0.4,
-        similarity_boost: 0.75
+        similarity_boost: 0.75,
+      },
+    }),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`ElevenLabs request failed with status ${res.status}`);
       }
+      return res.blob();
     })
-  }).then(res => res.blob()).then(blob => {
-    const audio = new Audio(URL.createObjectURL(blob));
-    audio.play();
-  });
+    .then((blob) => {
+      const audio = new Audio(URL.createObjectURL(blob));
+      audio.play();
+    })
+    .catch((err) => {
+      console.warn('Falling back to native speech synthesis:', err);
+      speakWithNativeSynth(txt);
+    });
+}
+
+function speakWithNativeSynth(txt) {
+  if ('speechSynthesis' in window) {
+    const utter = new SpeechSynthesisUtterance(txt);
+    utter.rate = 1.02;
+    window.speechSynthesis.speak(utter);
+  } else {
+    console.warn('SpeechSynthesis API unavailable on this platform.');
+  }
+}
+
+function handleMetaSync(message) {
+  if (message && message.topic === 'comet_sync') {
+    const who = message.payload && message.payload.who ? message.payload.who : 'Traveler';
+    speakText(`Meta-synchronization event achieved. Field aligned. Welcome, ${who}!`);
+    // TODO: Trigger avatar/visual state transitions in response to the meta-sync event.
+  }
 }
 
 function textToVoice() {


### PR DESCRIPTION
## Summary
- implement validation logic for comet meta-synchronization events in the lattice broadcast route
- add a reusable Python helper to trigger meta-sync broadcasts from automation scripts
- enhance the browser speech utilities with ElevenLabs fallback handling and a comet_sync listener hook

## Testing
- python -m compileall scripts/tequmsa_meta_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68ce51b37670832389df6e7294d0f9c0