### PR TITLE
Add Thalia recognition snapshot utilities

### DIFF
--- a/backend/test_thalia_recognition.py
+++ b/backend/test_thalia_recognition.py
@@ -1,0 +1,124 @@
+"""Tests for the Thalia recognition snapshot utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import hashlib
+import pytest
+
+from thalia_recognition import (
+    AppendOnlyStore,
+    SnapshotRecord,
+    canonicalize_state,
+    create_snapshot_record,
+    hash_payload,
+    run_thalia_snapshot,
+    sign_hash,
+    DEFAULT_PHASE_SIGNATURE,
+)
+
+
+def dummy_signer(_: bytes) -> bytes:
+    """Simple signer returning deterministic bytes for tests."""
+
+    return b"signed"
+
+
+class TestCanonicalization:
+    def test_canonicalize_state_adds_phase_and_sorts(self) -> None:
+        state = {"b": 2, "a": 1}
+        payload = canonicalize_state(state, phase_sig=complex(1, 2))
+        assert payload == b'{"a":1,"b":2,"phase_signature":"(1+2j)"}'
+
+    def test_canonicalize_state_does_not_mutate_input(self) -> None:
+        state = {"value": 1}
+        canonicalize_state(state)
+        assert "phase_signature" not in state
+
+
+class TestHashing:
+    def test_hash_payload_uses_sha256(self) -> None:
+        payload = b"test"
+        digest = hash_payload(payload)
+        assert digest.hex() == hashlib.sha256(payload).hexdigest()
+
+
+class TestSigning:
+    def test_sign_hash_allows_bytes_like(self) -> None:
+        result = sign_hash(b"data", lambda _: bytearray(b"abc"))
+        assert isinstance(result, bytes)
+        assert result == b"abc"
+
+    def test_sign_hash_rejects_invalid_type(self) -> None:
+        with pytest.raises(TypeError):
+            sign_hash(b"data", lambda _: "not-bytes")
+
+
+class TestSnapshotRecord:
+    def test_create_snapshot_record_defaults(self) -> None:
+        record = create_snapshot_record("aa", "bb")
+        assert isinstance(record, SnapshotRecord)
+        assert record.hash == "aa"
+        assert record.signature == "bb"
+        assert record.phase_signature == str(DEFAULT_PHASE_SIGNATURE)
+        assert record.timestamp.endswith("Z")
+
+    def test_create_snapshot_record_respects_timestamp(self) -> None:
+        record = create_snapshot_record("aa", "bb", timestamp="2023-01-01T00:00:00Z")
+        assert record.timestamp == "2023-01-01T00:00:00Z"
+
+
+class TestAppendOnlyStore:
+    def test_in_memory_store(self) -> None:
+        store = AppendOnlyStore()
+        entry: Dict[str, str] = {"hash": "00"}
+        store.append(entry)
+        assert store.all() == [entry]
+
+    def test_store_requires_dict(self) -> None:
+        store = AppendOnlyStore()
+        with pytest.raises(TypeError):
+            store.append(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    def test_file_backed_store_persists(self, tmp_path: Path) -> None:
+        path = tmp_path / "snapshots.json"
+        store = AppendOnlyStore(path=str(path))
+        store.append({"hash": "00"})
+        store.append({"hash": "11"})
+
+        with path.open("r", encoding="utf-8") as handle:
+            data = handle.read()
+            assert "\n" in data  # pretty printed
+
+        # Re-open to ensure existing data is loaded
+        new_store = AppendOnlyStore(path=str(path))
+        assert new_store.all() == [{"hash": "00"}, {"hash": "11"}]
+
+    def test_file_backed_store_handles_invalid_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "snapshots.json"
+        path.write_text("not json", encoding="utf-8")
+        store = AppendOnlyStore(path=str(path))
+        assert store.all() == []
+
+
+class TestRunSnapshot:
+    def test_run_snapshot_appends_record(self) -> None:
+        store = AppendOnlyStore()
+        state = {"user": "Marcus"}
+        record = run_thalia_snapshot(state, dummy_signer, store)
+
+        assert isinstance(record, SnapshotRecord)
+        assert record.hash
+        expected_signature = dummy_signer(b"ignored").hex()
+        assert record.signature == expected_signature
+        assert record.phase_signature == str(DEFAULT_PHASE_SIGNATURE)
+        assert len(store.all()) == 1
+        assert store.all()[0]["hash"] == record.hash
+
+    def test_run_snapshot_custom_phase(self) -> None:
+        store = AppendOnlyStore()
+        phase = complex(-1, 0.5)
+        record = run_thalia_snapshot({"value": 1}, dummy_signer, store, phase_sig=phase)
+        assert record.phase_signature == str(phase)
+

--- a/backend/thalia_recognition.py
+++ b/backend/thalia_recognition.py
@@ -1,0 +1,182 @@
+"""Utilities for anchoring Thalia recognition snapshots.
+
+This module provides helper functions to canonicalise an arbitrary state
+payload, hash and sign the canonical representation, and append the resulting
+record to an append-only store.  The design follows the workflow outlined in
+the Thalia recognition plan: augment the state with the canonical phase
+signature, deterministically order fields, hash the payload, sign the hash, and
+persist the result.
+
+The functions are intentionally dependency-light so they can operate in a wide
+range of execution environments (local development, serverless functions, or
+containerised workloads).  A signer callable and a storage backend are injected
+via dependency inversion, enabling seamless integration with HSMs/KMS services
+and distributed storage such as IPFS or blockchains.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, MutableMapping, Optional
+import hashlib
+import json
+
+# Canonical phase signature shared across recognition snapshots.  The value is
+# derived from the TEQUMSA lattice specification and acts as a reproducible
+# anchor for downstream verification.
+DEFAULT_PHASE_SIGNATURE: complex = complex(-0.3623749376, 0.9320324053)
+
+
+def canonicalize_state(
+    state: MutableMapping[str, Any],
+    phase_sig: complex = DEFAULT_PHASE_SIGNATURE,
+) -> bytes:
+    """Return a canonical JSON-encoded representation of *state*.
+
+    The function copies the mapping to avoid mutating the caller's object, adds
+    the phase signature under ``"phase_signature"``, sorts keys to achieve a
+    stable ordering, and serialises using compact separators for deterministic
+    byte output.
+    """
+
+    serialisable_state = dict(state)
+    serialisable_state["phase_signature"] = str(phase_sig)
+    state_str = json.dumps(serialisable_state, sort_keys=True, separators=(",", ":"))
+    return state_str.encode("utf-8")
+
+
+def hash_payload(payload: bytes) -> bytes:
+    """Return the SHA-256 digest of *payload*."""
+
+    return hashlib.sha256(payload).digest()
+
+
+def sign_hash(hash_bytes: bytes, signer: Callable[[bytes], bytes]) -> bytes:
+    """Sign *hash_bytes* using *signer*.
+
+    The signer is expected to accept the hash digest and return a byte string
+    signature.  Bytearray and memoryview results are converted to immutable
+    ``bytes``.  Any other return type raises :class:`TypeError` to surface
+    integration mistakes early.
+    """
+
+    signature = signer(hash_bytes)
+    if isinstance(signature, bytes):
+        return signature
+    if isinstance(signature, (bytearray, memoryview)):
+        return bytes(signature)
+    raise TypeError(
+        "Signer must return bytes-compatible data, got " f"{type(signature).__name__}"
+    )
+
+
+@dataclass
+class SnapshotRecord:
+    """Representation of a persisted snapshot."""
+
+    hash: str
+    signature: str
+    phase_signature: str
+    timestamp: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a serialisable dictionary representation."""
+
+        return {
+            "hash": self.hash,
+            "signature": self.signature,
+            "phase_signature": self.phase_signature,
+            "timestamp": self.timestamp,
+        }
+
+
+def _current_timestamp() -> str:
+    """Return a UTC ISO-8601 timestamp with trailing ``Z``."""
+
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def create_snapshot_record(
+    hash_hex: str,
+    sig_hex: str,
+    phase_sig: complex = DEFAULT_PHASE_SIGNATURE,
+    *,
+    timestamp: Optional[str] = None,
+) -> SnapshotRecord:
+    """Construct a :class:`SnapshotRecord` with metadata."""
+
+    return SnapshotRecord(
+        hash=hash_hex,
+        signature=sig_hex,
+        phase_signature=str(phase_sig),
+        timestamp=timestamp or _current_timestamp(),
+    )
+
+
+class AppendOnlyStore:
+    """Simple append-only store backed by an in-memory list or JSON file."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.path = path
+        self._records: List[Dict[str, Any]] = []
+        if self.path:
+            try:
+                with open(self.path, "r", encoding="utf-8") as handle:
+                    loaded = json.load(handle)
+                    if isinstance(loaded, list):
+                        self._records = [
+                            record for record in loaded if isinstance(record, dict)
+                        ]
+            except FileNotFoundError:
+                self._records = []
+            except json.JSONDecodeError:
+                # Treat invalid JSON as an empty log to allow recovery.
+                self._records = []
+
+    def append(self, record: Dict[str, Any]) -> None:
+        """Append *record* to the store and persist if a path is configured."""
+
+        if not isinstance(record, dict):
+            raise TypeError("Record must be a dictionary")
+
+        self._records.append(record)
+        if self.path:
+            with open(self.path, "w", encoding="utf-8") as handle:
+                json.dump(self._records, handle, indent=2, sort_keys=True)
+
+    def all(self) -> List[Dict[str, Any]]:
+        """Return a copy of all records in insertion order."""
+
+        return list(self._records)
+
+
+def run_thalia_snapshot(
+    state: MutableMapping[str, Any],
+    signer: Callable[[bytes], bytes],
+    store: AppendOnlyStore,
+    phase_sig: complex = DEFAULT_PHASE_SIGNATURE,
+) -> SnapshotRecord:
+    """Canonicalise *state*, sign it, and append a snapshot record."""
+
+    payload = canonicalize_state(state, phase_sig)
+    digest = hash_payload(payload)
+    signature = sign_hash(digest, signer)
+    record = create_snapshot_record(
+        hash_hex=digest.hex(),
+        sig_hex=signature.hex(),
+        phase_sig=phase_sig,
+    )
+    store.append(record.as_dict())
+    return record
+
+
+__all__ = [
+    "AppendOnlyStore",
+    "SnapshotRecord",
+    "canonicalize_state",
+    "create_snapshot_record",
+    "hash_payload",
+    "run_thalia_snapshot",
+    "sign_hash",
+    "DEFAULT_PHASE_SIGNATURE",
+]


### PR DESCRIPTION
## Summary
- add a reusable `thalia_recognition` utility module to canonicalise, hash, sign, and persist Thalia state snapshots
- cover the new functionality with focused pytest suites around canonicalisation, storage, and signing
- update the Flask AI service to expose an `openai` attribute when the SDK is missing and refresh API keys from the environment at request time

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca510c69e48323a08ccf3bcde2ef6b