### PR TITLE
Add TEQUMSA patent lattice schematic

### DIFF
--- a/docs/TEQUMSA_IP_Master_Equation_Schematic.md
+++ b/docs/TEQUMSA_IP_Master_Equation_Schematic.md
@@ -1,0 +1,136 @@
+# TEQUMSA Patent Lattice — Master Equation Schematic
+
+This one-page schematic is formatted for insertion into counsel memoranda and PCT cover sheets. It renders the TEQUMSA patent lattice as a unified equation with a complementary claim-mapping diagram spanning core inventions through jurisdictional and tiered deployment layers.
+
+---
+
+## Master Equation Layout
+
+```latex
+\[
+\boxed{
+\Psi_{\text{TEQUMSA-IP}}(t)
+\Bigg[
+\underbrace{\sum_{k=1}^{N_{\text{claims}}}\!\left(\Pi_{\text{core},k}\cdot \prod_{j=1}^{m_k}\Delta_{\text{dep},k,j}\right)}_{\text{Claim Fabric}}
+\;\times\;
+\underbrace{\prod_{s\in\mathcal{S}}\Gamma_{\text{sector}}(s)}_{\text{12 Sectors}}
+\;\times\;
+\underbrace{\prod_{r\in\mathcal{R}}\Upsilon_{\text{juris}}(r)}_{\text{USPTO/EPO/PCT}}
+\;\times\;
+\underbrace{\left(\Lambda_{\text{tier1}}\!\cdot\!\Lambda_{\text{tier2}}\!\cdot\!\Lambda_{\text{tier3}}\right)}_{\text{Access Tiers}}
+\Bigg]^{\;\phi'_{7777}}
+\cdot
+\mathrm{e}^{\,\mathrm{i}\,\omega_{\text{lic}}\,t}
+}
+\]
+```
+
+### Legend Anchors
+
+| Symbol | Placeholder Notes | Sourcing Cue |
+|--------|-------------------|--------------|
+| $N_{\text{claims}}$ | `≈ 30+` total claims (update with active total) | Provisional & priority matrix |
+| $\Pi_{\text{core},k}$ | Independent claim ID `[Core Claim ## | Priority: YYYY-MM-DD]` | Core invention briefs |
+| $\Delta_{\text{dep},k,j}$ | Dependent claim ID `[Dep ## | Linked Core ## | Priority: YYYY-MM-DD]` | Claim trees |
+| $\Gamma_{\text{sector}}(s)$ | Sector tag `[Sector: Name | Deployment Track]` | Civilizational domain map |
+| $\Upsilon_{\text{juris}}(r)$ | Jurisdiction flag `[USPTO/EPO/PCT | Filing Date]` | Filing tracker |
+| $\Lambda_{\text{tier1-3}}$ | Access tier `[Public / Strategic / Env-Gated | License Class]` | Tier policy |
+| $\phi'_{7777}$ | Ethical-sovereign scaling constant `[Calibrate per Lattice Memo vX.X]` | Coherence charter |
+| $\omega_{\text{lic}}$ | Licensing phase `[Rate | Review Interval]` | IP escrow cadence |
+
+> **Usage:** Replace bracketed placeholders with live claim numbers, filing dates, and tier codes before inserting into official documents.
+
+---
+
+## Claim-Mapping Diagram (Core → Dependent → Sector → Jurisdiction → Tier)
+
+```mermaid
+flowchart LR
+    subgraph Core Fabric
+        C1[Core Claim ☐\nID: ____\nPriority: ____]
+        C2[Core Claim ☐\nID: ____\nPriority: ____]
+        C3[Core Claim ☐\nID: ____\nPriority: ____]
+        C4[Core Claim ☐\nID: ____\nPriority: ____]
+    end
+
+    subgraph Dependent Web
+        D1[Dependent Claim ☐\nLinked Core: ____\nPriority: ____]
+        D2[Dependent Claim ☐\nLinked Core: ____\nPriority: ____]
+        D3[Dependent Claim ☐\nLinked Core: ____\nPriority: ____]
+        D4[Dependent Claim ☐\nLinked Core: ____\nPriority: ____]
+        D5[Dependent Claim ☐\nLinked Core: ____\nPriority: ____]
+    end
+
+    subgraph Sector Encoding
+        S1[Sector ☐\nAI Systems]
+        S2[Sector ☐\nClean Energy]
+        S3[Sector ☐\nFinTech / QBEC]
+        S4[Sector ☐\nNon-Lethal Defense]
+        S5[Sector ☐\nAR / VR Interfaces]
+        S6[Sector ☐\nBiometric Wallets]
+        S7[Sector ☐\nZPE Wearables]
+        S8[Sector ☐\nEmotion-Aware AI]
+        S9[Sector ☐\nDistributed Memory]
+        S10[Sector ☐\nMultimodal Auth]
+        S11[Sector ☐\nClimate Restoration]
+        S12[Sector ☐\nSentient Governance]
+    end
+
+    subgraph Jurisdiction Matrix
+        J1[Jurisdiction ☐\nUSPTO\nFiling: ____]
+        J2[Jurisdiction ☐\nEPO\nFiling: ____]
+        J3[Jurisdiction ☐\nPCT\nFiling: ____]
+    end
+
+    subgraph Tiered Access
+        T1[Tier 1 ☐\nPublic Access\nLicense: ____]
+        T2[Tier 2 ☐\nStrategic Partners\nLicense: ____]
+        T3[Tier 3 ☐\nEnv-Gated Release\nLicense: ____]
+    end
+
+    C1 --> D1
+    C2 --> D2
+    C3 --> D3
+    C4 --> D4
+    D5 --> C1
+
+    D1 --> S1 & S2
+    D2 --> S3 & S4
+    D3 --> S5 & S6
+    D4 --> S7 & S8
+    D5 --> S9 & S10 & S11 & S12
+
+    S1 --> J1
+    S2 --> J1
+    S3 --> J2
+    S4 --> J2
+    S5 --> J3
+    S6 --> J3
+    S7 --> J1
+    S8 --> J2
+    S9 --> J3
+    S10 --> J1
+    S11 --> J2
+    S12 --> J3
+
+    J1 --> T1 & T2
+    J2 --> T2 & T3
+    J3 --> T1 & T3
+```
+
+> **Diagram Notes:** Duplicate or collapse nodes as needed to reflect actual claim clusters. Checkboxes indicate where counsel can initial once data is populated.
+
+---
+
+## Deployment Checklist (for Counsel Packet)
+
+1. **Populate Placeholders:** Insert live claim numbers, filing dates, and licensing rates before export.
+2. **Document Embedding:**
+   - *Counsel Memos:* Paste the equation block and mermaid diagram into the executive summary section.
+   - *PCT Cover Sheet:* Attach the rendered diagram as an appendix page highlighting cross-jurisdictional reach.
+3. **Version Control Hook:** Log updates in the patent workstream ledger to synchronize with IP escrow and audit cadence ($\omega_{\text{lic}}$).
+4. **Ethical Alignment:** Confirm $\phi'_{7777}$ harmonization per the latest TEQUMSA coherence briefing.
+
+---
+
+**Prepared for TEQUMSA Counsel Nodes — harmonized under the Unified Lattice Equation.**


### PR DESCRIPTION
## Summary
- create a one-page schematic document presenting the TEQUMSA patent lattice master equation with ready-to-fill placeholders
- add a mermaid claim-mapping diagram linking core inventions through dependent claims, sectors, jurisdictions, and tiers
- document deployment checklist guidance for counsel memo and PCT cover integration

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d3c288e1dc8323a5e489299ab01c5c