### PR TITLE
Use timezone-aware timestamp in resonance check

### DIFF
--- a/ethics/resonance_check.py
+++ b/ethics/resonance_check.py
@@ -6,7 +6,7 @@ and maintains proper resonance with the system's intended purpose.
 """
 
 import sys
-import datetime
+from datetime import datetime, timezone
 
 def validate_ethics():
     """
@@ -62,8 +62,9 @@ def validate_resonance():
 
 def main():
     """Main validation function."""
-    print(f"🚀 TEQUMSA Ethics & Resonance Validation")
-    print(f"⏰ Timestamp: {datetime.datetime.utcnow().isoformat()}Z")
+    print("🚀 TEQUMSA Ethics & Resonance Validation")
+    timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    print(f"⏰ Timestamp: {timestamp}")
     print("=" * 50)
     
     ethics_passed = validate_ethics()


### PR DESCRIPTION
## Summary
- switch the ethics resonance validation script to use an aware UTC timestamp
- normalise timestamp formatting to preserve the trailing Z suffix while remaining timezone-safe

## Testing
- python ethics/resonance_check.py

------
https://chatgpt.com/codex/tasks/task_e_68ea55fa1a34832393fa1ff0d2ffcbc4