### PR TITLE
Potential fix for code scanning alert no. 249: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hf_sync.yml
+++ b/.github/workflows/hf_sync.yml
@@ -68,6 +68,8 @@ jobs:
     needs: sync-hf-organism
     if: success()
 
+    permissions: {}
+
     steps:
       - name: ✅ Log success
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/Life-Ambassadors-International/TEQUMSA_NEXUS/security/code-scanning/249](https://github.com/Life-Ambassadors-International/TEQUMSA_NEXUS/security/code-scanning/249)

Add an explicit `permissions` block for the `notify-success` job (or set a workflow-level permissions block).  
The **best minimal fix** without changing functionality is to add job-level permissions under `notify-success` with no granted scopes (`{}`), since this job only logs messages and does not need token access.

**File to change:** `.github/workflows/hf_sync.yml`  
**Region:** `notify-success` job header (around lines 66–71), before `steps:`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
